### PR TITLE
Publish Validation Packages to Public Registry

### DIFF
--- a/common/config/azure-pipelines/buildPublishPackages.yaml
+++ b/common/config/azure-pipelines/buildPublishPackages.yaml
@@ -149,13 +149,14 @@ stages:
           targetPath: '$(Build.ArtifactStagingDirectory)/bis-schema-tools/packages'
           artifact: packages
         condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual', 'BuildCompletion'))
-- stage: publish
+
+- stage: Publish_Packages_Internal
   dependsOn: build
-  displayName: Publish
+  displayName: Publish Packages Internal
   condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual', 'BuildCompletion'))
   jobs:
-  - job: publish_artifacts
-    displayName: Publish packages to Artifacts
+  - job: PublishInternal
+    displayName: Publish Packages to Azure Artifacts
     strategy:
       maxParallel: 2
       matrix:
@@ -193,6 +194,61 @@ stages:
           Write-Output ("Processing Artifact: '" + $artifactPath.Name + "'...")
 
           $cmd = "npm publish $artifactPath 2> `$null"
+
+          Write-Output ("Running '" + $cmd + "'...")
+
+          npm publish $artifactPath
+          Write-Output ("Done processing Artifact: '" + $artifactPath.Name + "'...")
+        }
+
+        Pop-Location
+
+- stage: Publish_Packages_External
+  dependsOn: build
+  displayName: Publish Packages External
+  condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'Schedule', 'Manual', 'BuildCompletion'))
+  jobs:
+  - job: PublishExternal
+    displayName: Publish Packages to NPMJS
+    strategy:
+      maxParallel: 2
+      matrix:
+        'Windows':
+          os: vs2017-win2016
+    pool:
+      vmImage: $(os)
+    variables:
+    - group: "Caleb - npmjs publish token"
+    - name: packsDir
+      value: $(System.ArtifactsDirectory)/packages/
+    - name: releaseTag
+      value: latest
+
+    steps:
+    - checkout: none
+      clean: true
+    - task: DownloadPipelineArtifact@1
+      displayName: Download packages to publish
+      inputs:
+        buildType: current
+        artifactName: packages
+        targetPath: $(packsDir)
+
+    - template: ./seed-npmjs-npmrc.yaml
+      parameters: { npmToken: $(npmToken) }
+
+    - powershell: |
+        $artifactPaths = Get-ChildItem "$(packsDir)\*.tgz"
+
+        Push-Location $(System.ArtifactsDirectory)/packages/
+
+        npm config list
+
+        foreach ($artifactPath in $artifactPaths) {
+          Write-Output ""
+          Write-Output ("Processing Artifact: '" + $artifactPath.Name + "'...")
+
+          $cmd = "npm publish $artifactPath --tag $(releaseTag) --access public 2> `$null"
 
           Write-Output ("Running '" + $cmd + "'...")
 

--- a/common/config/azure-pipelines/seed-npmjs-npmrc.yaml
+++ b/common/config/azure-pipelines/seed-npmjs-npmrc.yaml
@@ -1,0 +1,9 @@
+parameters: { npmToken: '' }
+
+steps:
+  - bash: |
+      npm config set @bentley:registry=https://registry.npmjs.org/
+      npm config set //registry.npmjs.org/:_authToken=${{ parameters.npmToken }}
+      npm config set //registry.npmjs.org/:email='imodel.js@gmail.com'
+      npm config set //registry.npmjs.org/:username='imodeljs'
+    displayName: 'Seed npmrc'


### PR DESCRIPTION
This new section in the YAML will be used for releasing the packages to the public registry (https://registry.npmjs.org/).