### PR TITLE
Default Registry to Build and Trigger Specification

### DIFF
--- a/common/config/azure-pipelines/buildPublishPackages.yaml
+++ b/common/config/azure-pipelines/buildPublishPackages.yaml
@@ -6,6 +6,13 @@ resources:
       type: github
       endpoint: BisSchemasGitHub
       name: iTwin/bis-schemas
+  pipelines:
+  - pipeline: BIS-Schema-Tools-Version-Bump
+    source: BIS-Schema-Tools-Version-Bump-(GitHub)
+    trigger:
+      branches:
+        include:
+        - master
 
 stages:
 - stage: build
@@ -29,10 +36,6 @@ stages:
         inputs:
           versionSpec: 12.18.2
           checkLatest: true
-
-      #Your build pipeline references a secret variable named ‘artifactsRegistryToken’. This variable is pulled from the 'arzure-artifacts-npm-token' variable group.  You must authorize this build to use that group: https://docs.microsoft.com/en-us/azure/devops/pipelines/library/variable-groups?view=azure-devops&tabs=yaml#use-a-variable-group
-      - template: seed-npmrc.yaml
-        parameters: { artifactsRegistryToken: $(artifactsRegistryToken) }
 
       - script: node $(System.DefaultWorkingDirectory)/bis-schema-validation/common/scripts/install-run-rush.js check
         displayName: Rush check


### PR DESCRIPTION
Default (public) registry should be consumed to build as the packages are now available at npmjs.

After completion of the version bump build, auto trigger the pipeline.