### PR TITLE
Testcase: schema comparison for null vs empty description ensures no differences detected

### DIFF
--- a/schema-comparer/src/test/SchemaComparison.test.ts
+++ b/schema-comparer/src/test/SchemaComparison.test.ts
@@ -49,6 +49,19 @@ describe("SchemaValidater Tests", () => {
     expect(schemaB.fullName).to.equal("SchemaB");
   });
 
+  it.only("Missing vs empty description, no differences found, results are correct", async () => {
+    const schemaOldPath = path.resolve(assetsDir, "SchemaWithNoDescription.ecschema.xml");
+    const schemaNewPath = path.resolve(assetsDir, "SchemaWithEmptyDescription.ecschema.xml");
+    const options = new CompareOptions(schemaOldPath, schemaNewPath, [referencesDir], [referencesDir]);
+
+    const results = await SchemaComparison.compare(options);
+
+    expect(results[0].resultType).to.equal(ComparisonResultType.Message);
+    expect(results[0].resultText).to.equal("Schema Comparison Results");
+    expect(results[1].resultType).to.equal(ComparisonResultType.Message);
+    expect(results[1].resultText).to.equal(" Schema Comparison Succeeded. No differences found.");
+  });
+
   it("Compare two schema files, out directory specified, result file created correctly", async () => {
     const schemaAFile = path.resolve(assetsDir, "SchemaA.ecschema.xml");
     const schemaBFile = path.resolve(assetsDir, "SchemaA.ecschema.xml");

--- a/schema-comparer/src/test/assets/SchemaWithEmptyDescription.ecschema.xml
+++ b/schema-comparer/src/test/assets/SchemaWithEmptyDescription.ecschema.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ECSchema schemaName="ElementDrivesTest" alias="edt" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+  <ECEntityClass typeName="DummySource" />
+  <ECEntityClass typeName="DummyTarget" />
+
+  <ECRelationshipClass typeName="ElementDrivesElementsLinearly" modifier="None" strength="referencing" strengthDirection="forward" description="">
+    <Source multiplicity="(0..1)" roleLabel="source" polymorphic="True">
+      <Class class="DummySource" />
+    </Source>
+    <Target multiplicity="(0..*)" roleLabel="target" polymorphic="True">
+      <Class class="DummyTarget" />
+    </Target>
+  </ECRelationshipClass>
+
+</ECSchema>

--- a/schema-comparer/src/test/assets/SchemaWithNoDescription.ecschema.xml
+++ b/schema-comparer/src/test/assets/SchemaWithNoDescription.ecschema.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ECSchema schemaName="ElementDrivesTest" alias="edt" version="01.00.00" xmlns="http://www.bentley.com/schemas/Bentley.ECXML.3.2">
+  <ECEntityClass typeName="DummySource" />
+  <ECEntityClass typeName="DummyTarget" />
+  <ECRelationshipClass typeName="ElementDrivesElementsLinearly" modifier="None" strength="referencing" strengthDirection="forward">
+    <Source multiplicity="(0..1)" roleLabel="source" polymorphic="True">
+      <Class class="DummySource" />
+    </Source>
+    <Target multiplicity="(0..*)" roleLabel="target" polymorphic="True">
+      <Class class="DummyTarget" />
+    </Target>
+  </ECRelationshipClass>
+
+</ECSchema>


### PR DESCRIPTION
Issue Link: https://github.com/iTwin/bis-schema-validation/issues/61

- Added testcase for schema comparison with
       One schema having no description attribute
      Other schema having an empty description attribute

- Solution for this scenario already exists in the core repo: -https://github.com/iTwin/itwinjs-core/pull/8333  

- Here we are verifying that the solution works as expected in our tests